### PR TITLE
fix(pdf): area highlights don't blink

### DIFF
--- a/src/main/frontend/extensions/pdf/core.cljs
+++ b/src/main/frontend/extensions/pdf/core.cljs
@@ -370,7 +370,7 @@
     (when-let [vw-bounding (get-in vw-hl [:position :bounding])]
       (let [{:keys [color]} (:properties hl)]
         [:div.extensions__pdf-hls-area-region
-         {:id              id
+         {:id              (str "hl_" id)
           :ref             *el
           :style           vw-bounding
           :data-color      color


### PR DESCRIPTION
Area highlights don't blink when jumping to it.

This PR unifies the id naming style of all highlights elements. As a result, area highlights will blink as text highlights do.

[The part for blinking](https://github.com/e-zz/logseq/blob/27e3b9d019fc39c875616205f96d234cb307dddc/src/main/frontend/extensions/pdf/utils.js#L123C5-L130) in `pdf/utils.js`
``` js
  // blink highlight
  function blinkHighlight () {
    const id = highlight?.id
    const el = document.getElementById(`hl_${id}`)
    if (!el) return
    el.classList.add('hl-flash')
    setTimeout(() => el?.classList.remove('hl-flash'), 1200)
  }
```

PS: I don't know if disabling the blinking is by design. Let me know if it's not a bug but a feature :)